### PR TITLE
Cleanup API

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -56,8 +56,8 @@ This prototype is implemented using Express/Jade view rendering and hacked toget
 ##### Example requests body
 ```javascript
 {
-	"datetimePattern": "/\\[(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\]/",
-	"levelPattern": "/\\[([\\w\\s]+|\\w+)\\]:\\s/",
+	"datetimePattern": "\\[(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\]",
+	"levelPattern": "\\[([\\w\\s]+|\\w+)\\]:\\s",
 	"timeFormatter": "h:MM:ss",
 	"folders": [
 		{
@@ -74,8 +74,8 @@ This prototype is implemented using Express/Jade view rendering and hacked toget
 	"success": true,
 	"msg": "Config set: true",
 	"data": {
-		"datetimePattern": "/\\[(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\]/",
-		"levelPattern": "/\\[([\\w\\s]+|\\w+)\\]:\\s/",
+		"datetimePattern": "\\[(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\]",
+		"levelPattern": "\\[([\\w\\s]+|\\w+)\\]:\\s",
 		"timeFormatter": "h:MM:ss",
 		"folders": [
 			{
@@ -95,8 +95,8 @@ This prototype is implemented using Express/Jade view rendering and hacked toget
 	"success": true,
 	"msg": "Config read",
 	"data": {
-		"datetimePattern": "/\\[(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\]/",
-		"levelPattern": "/\\[([\\w\\s]+|\\w+)\\]:\\s/",
+		"datetimePattern": "\\[(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\]",
+		"levelPattern": "\\[([\\w\\s]+|\\w+)\\]:\\s",
 		"timeFormatter": "h:MM:ss",
 		"folders": [
 			{
@@ -136,46 +136,44 @@ This prototype is implemented using Express/Jade view rendering and hacked toget
 ```javascript
 {
 	"success": true,
-	"msg": "Queried logfile",
-	"data": {
-		"logentries": [
-			{
-				"text": "You must be pretty desperate if you're looking at the logs",
-				"level": 2,
-				"levelStr": "info",
-				"datetime": 1489387840000,
-				"datetimeStr": "11:50:40"
-			},
-			{
-				"text": "Hello world",
-				"level": 0,
-				"levelStr": "error",
-				"datetime": 1489387841000,
-				"datetimeStr": "11:50:41"
-			},
-			{
-				"text": "Lovely weather we're having",
-				"level": 1,
-				"levelStr": "warn",
-				"datetime": 1489387841000,
-				"datetimeStr": "11:50:41"
-			},
-			{
-				"text": "That's all for now folks",
-				"level": 4,
-				"levelStr": "debug",
-				"datetime": 1489387841000,
-				"datetimeStr": "11:50:41"
-			},
-			{
-				"text": "You must be pretty desperate if you're looking at the logs",
-				"level": 4,
-				"levelStr": "debug",
-				"datetime": 1489387840000,
-				"datetimeStr": "11:50:40"
-			}
-		]
-	}
+	"msg": "Queried /Users/nick/Documents/slask/src/server/test/fixtures/testlog.log",
+	"data": [
+		{
+			"text": "You must be pretty desperate if you're looking at the logs",
+			"level": 2,
+			"levelStr": "info",
+			"datetime": 1489387840000,
+			"datetimeStr": "6:50:40"
+		},
+		{
+			"text": "Hello world",
+			"level": 0,
+			"levelStr": "error",
+			"datetime": 1489387841000,
+			"datetimeStr": "6:50:41"
+		},
+		{
+			"text": "Lovely weather we're having",
+			"level": 1,
+			"levelStr": "warn",
+			"datetime": 1489387841000,
+			"datetimeStr": "6:50:41"
+		},
+		{
+			"text": "That's all for now folks",
+			"level": 4,
+			"levelStr": "debug",
+			"datetime": 1489387841000,
+			"datetimeStr": "6:50:41"
+		},
+		{
+			"text": "You must be pretty desperate if you're looking at the logs",
+			"level": 4,
+			"levelStr": "debug",
+			"datetime": 1489387840000,
+			"datetimeStr": "6:50:40"
+		}
+	]
 }
 ```
 
@@ -186,14 +184,10 @@ Gets the directory listing for the first folder configured in `config.folders`
 ##### Example Response
 ```javascript
 {
-	"logFiles": [
-		"debug_debug_livelog.log",
-		"debug_debug_livelog1.log",
-		"debug_debug_livelog2.log",
-		"debug_debug_livelog3.log",
-		"debug_livelog.log",
-		"debug_livelog1.log",
-		"debug_livelog2.log"
+	"success": true,
+	"msg": "Successfully listed /Users/nick/Documents/slask/src/server/test/fixtures",
+	"data": [
+		"testlog.log"
 	]
 }
 ```

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
-  "datetimePattern": "/\\[(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\]/",
-  "levelPattern": "/\\[([\\w\\s]+|\\w+)\\]:\\s/",
+  "datetimePattern": "\\[(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z)\\]",
+  "levelPattern": "\\[([\\w\\s]+|\\w+)\\]:\\s",
   "timeFormatter": "h:MM:ss",
   "folders": [
     {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "express": "~4.13.4",
     "fs-extra": "^2.0.0",
     "heap": "^0.2.6",
-    "json-is-equal": "^1.0.0",
     "lodash": "^4.17.4",
     "mocha": "^3.2.0",
     "morgan": "~1.7.0",

--- a/src/server/models/config.js
+++ b/src/server/models/config.js
@@ -4,13 +4,13 @@ const fs = require('fs-extra');
 const buildRes = require('../helpers/build-res');
 
 const Config = {
-  createConfig: function(configPath){
+  create: function(configPath){
     this.configPath = configPath;
     this.blob = {};
-    this.readConfig();
+    this.read();
     return this;
   },
-  readConfig: function(){
+  read: function(){
     const configExists = fs.existsSync(this.configPath);
     let toReturn = buildRes(true, 'Config file is empty', {});
     if(configExists){
@@ -25,13 +25,13 @@ const Config = {
     }
     return toReturn;
   },
-  setConfig: function(config){
+  set: function(config){
     this.blob = config;
     console.log(JSON.stringify(this.blob));
-    const success = this.saveConfig(config);
+    const success = this.save(config);
     return buildRes(success, `Config set: ${success}`, config);
   },
-  saveConfig: function(config){
+  save: function(config){
     try{
       fs.outputJsonSync(this.configPath, config);
     }

--- a/src/server/models/config.js
+++ b/src/server/models/config.js
@@ -27,7 +27,6 @@ const Config = {
   },
   set: function(config){
     this.blob = config;
-    console.log(JSON.stringify(this.blob));
     const success = this.save(config);
     return buildRes(success, `Config set: ${success}`, config);
   },

--- a/src/server/models/folder.js
+++ b/src/server/models/folder.js
@@ -1,30 +1,31 @@
 'use strict';
 
 const walk = require('walk');
+const buildRes = require('../helpers/build-res');
 
 /**
- * Walks a given directory for log files (used in sidebar)
+ * Walks a given direcory for log files (used in sidebar)
  *
- * @param logDir: string
+ * @param direc: string
  *  Path to log direcory
  * @returns: {Promise}
  *  Resolves with a list of lognames
  */
-exports.getLogFileNames = (logDir) => {
+module.exports = direc => {
   return new Promise((resolve, reject) => {
-    let logFileNames = [];
-    let walker = walk.walk(logDir);
+    let filenames = [];
+    let walker = walk.walk(direc);
     walker.on('file', (root, fileStats, next) => {
-      logFileNames.push(fileStats.name);
+      filenames.push(fileStats.name);
       next();
     });
 
     walker.on('end', () => {
-      resolve(logFileNames);
+      resolve(buildRes(true, `Successfully listed ${direc}`, filenames));
     });
 
     walker.on('error', err => {
-      reject(err);
+      reject(buildRes(false, `Failed to list ${direc}: ${err.message}`));
     })
   });
 };

--- a/src/server/models/logfile.js
+++ b/src/server/models/logfile.js
@@ -83,7 +83,7 @@ const Logfile = {
       const levelMatch = logline.level <= queryParams.level;
       return datetimeMatch && levelMatch;
     });
-    if(!isValidPagenum(filtered.length, queryParams.pagesize, queryParams.pagenum))
+    if(!isValidPagenum(filtered.length, queryParams.pagesize, queryParams.pagenum) && filtered.length)
       throw new Error('pagenum out of range');
     // pages go from newest -> oldest so reverse the page chunks
     const loglines = _.chunk(filtered, queryParams.pagesize).reverse()[queryParams.pagenum - 1];

--- a/src/server/models/logfile.js
+++ b/src/server/models/logfile.js
@@ -5,6 +5,7 @@ const dateFormat = require('dateformat');
 const _ = require('lodash');
 
 const constants = require('../helpers/constants');
+const buildRes = require('../helpers/build-res');
 
 const DEFAULT_LEVEL = constants.defaultLevel;
 const DEFAULT_LEVEL_STR = constants.defaultLevelStr;
@@ -12,8 +13,8 @@ const DEFAULT_SPLIT_STR = '\n'; // TODO put this in config
 
 function parseLine(datetimePattern, levelPattern, timeFormatter){
   return function(line){
-    const dateSplit = line.split(new RegExp(datetimePattern.slice(1,-1)));
-    const levelSplit = dateSplit[2].split(new RegExp(levelPattern.slice(1, -1)));
+    const dateSplit = line.split(new RegExp(datetimePattern));
+    const levelSplit = dateSplit[2].split(new RegExp(levelPattern));
     const levelObj = getLevel(levelSplit[1], constants.levels);
     const dateObj = new Date(dateSplit[1]);
     return {
@@ -85,10 +86,11 @@ const Logfile = {
     if(!isValidPagenum(filtered.length, queryParams.pagesize, queryParams.pagenum))
       throw new Error('pagenum out of range');
     // pages go from newest -> oldest so reverse the page chunks
-    return _.chunk(filtered, queryParams.pagesize).reverse()[queryParams.pagenum - 1];
+    const loglines = _.chunk(filtered, queryParams.pagesize).reverse()[queryParams.pagenum - 1];
+    return buildRes(true, `Queried ${this.filepath}`, loglines);
   },
   getAll: function(){
-    return this.loglines;
+    return buildRes(true, `Retrieved all loglines for ${this.filepath}`, this.loglines);
   }
 };
 

--- a/src/server/test/api.test.js
+++ b/src/server/test/api.test.js
@@ -47,13 +47,14 @@ describe('REST API', function(){
   describe('#directory()', function(){
     it(`should contain ${LOGFILE_NAME}`, function(){
       return get(DIRECTORY_ROUTE).then(body => {
-        assert.include(body.data, LOGFILE_NAME);
+        assert.include(body.data, LOGFILE_NAME, `directory list did not include ${LOGFILE_NAME}`);
       })
     })
   });
 
   describe('#query()', function(){
     const thisGet = () => get(FILE_ROUTE, { logfile: LOGFILE_NAME });
+    const bodyFailMsg = 'query request failed';
     it('should correctly parse the first line', function(){
       const correct = {
         text: `You must be pretty desperate if you're looking at the logs`,
@@ -63,21 +64,32 @@ describe('REST API', function(){
         datetimeStr: '6:50:40'
       };
       return thisGet().then(body => {
-        assert(body.success);
+        assert(body.success, bodyFailMsg);
         assert.deepEqual(body.data[0], correct, 'did not correctly parse logline');
       });
     });
 
+    it('should return an empty list for a future date range', function(){
+      return get(FILE_ROUTE, {
+        logfile: LOGFILE_NAME,
+        startdt: Date.now() + 1 * 1000 * 60,
+        enddt: Date.now() + 2 * 1000 * 60
+      }).then(body => {
+        assert(body.success, bodyFailMsg);
+        assert(!body.data, 'returned non-empty list for future date query'); // TODO this should check length
+      })
+    })
+
     it('should default level on unknown level', function(){
       return thisGet().then(function(body){
-        assert(body.success);
+        assert(body.success, bodyFailMsg);
         assert.strictEqual(body.data[4].level, constants.defaultLevel, 'level did not default');
       });
     });
 
     it('should default level string on unknown level', function(){
       return thisGet().then(function(body){
-        assert(body.success);
+        assert(body.success, bodyFailMsg);
         assert.strictEqual(body.data[4].levelStr, constants.defaultLevelStr,
             'level string did not defualt');
       })

--- a/src/server/test/api.test.js
+++ b/src/server/test/api.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const assert = require('chai').assert;
-const isEqual = require('json-is-equal');
 const path = require('path');
 
 const http = require('./lib/http');
@@ -16,15 +15,16 @@ const LOGFILE_NAME = 'testlog.log';
 const TEST_PORT = 5000;
 const BASE_ROUTE = `http://localhost:${TEST_PORT}/api`;
 const CONFIG_ROUTE = `${BASE_ROUTE}/config`;
-const FILE_ROUTE = `${BASE_ROUTE}/file`
+const FILE_ROUTE = `${BASE_ROUTE}/file`;
+const DIRECTORY_ROUTE = `${BASE_ROUTE}/directory`;
 
 describe('REST API', function(){
 
   const server = createServer(TEST_PORT); // eslint-disable-line
   describe('#config()', function(){
     const config = {
-      datetimePattern: constants.defaultDatetimePattern.toString(),
-      levelPattern: constants.defaultLevelPattern.toString(),
+      datetimePattern: constants.defaultDatetimePattern.toString().slice(1, -1),
+      levelPattern: constants.defaultLevelPattern.toString().slice(1, -1),
       timeFormatter: constants.defaultTimeFormatter,
       folders: [{
         name: "Test Fixture",
@@ -38,9 +38,17 @@ describe('REST API', function(){
     });
   });
 
+  describe('#directory()', function(){
+    it(`should contain ${LOGFILE_NAME}`, function(){
+      return get(DIRECTORY_ROUTE).then(body => {
+        assert.include(body.data, LOGFILE_NAME);
+      })
+    })
+  });
+
   describe('#query()', function(){
     const thisGet = () => get(FILE_ROUTE, { logfile: LOGFILE_NAME });
-    it('should correctly parse the first line', function(done){
+    it('should correctly parse the first line', function(){
       const correct = {
         text: `You must be pretty desperate if you're looking at the logs`,
         level: constants.levels.INFO,
@@ -48,21 +56,21 @@ describe('REST API', function(){
         datetime: 1489387840000,
         datetimeStr: '6:50:40'
       };
-      thisGet().then(body => {
-        if(body.success && isEqual(body.data.logentries[0], correct)) done();
-        else done(new Error('Request failed'));
+      return thisGet().then(body => {
+        assert.deepEqual(body.data[0], correct, 'did not correctly parse logline');
+        assert(body.success)
       });
     });
 
     it('should default level on unknown level', function(){
       return thisGet().then(function(body){
-        assert.strictEqual(body.data.logentries[4].level, constants.defaultLevel, 'level did not default');
+        assert.strictEqual(body.data[4].level, constants.defaultLevel, 'level did not default');
       });
     });
 
     it('should default level string on unknown level', function(){
       return thisGet().then(function(body){
-        assert.strictEqual(body.data.logentries[4].levelStr, constants.defaultLevelStr,
+        assert.strictEqual(body.data[4].levelStr, constants.defaultLevelStr,
             'level string did not defualt');
       })
     });

--- a/src/server/test/api.test.js
+++ b/src/server/test/api.test.js
@@ -57,19 +57,21 @@ describe('REST API', function(){
         datetimeStr: '6:50:40'
       };
       return thisGet().then(body => {
+        assert(body.success);
         assert.deepEqual(body.data[0], correct, 'did not correctly parse logline');
-        assert(body.success)
       });
     });
 
     it('should default level on unknown level', function(){
       return thisGet().then(function(body){
+        assert(body.success);
         assert.strictEqual(body.data[4].level, constants.defaultLevel, 'level did not default');
       });
     });
 
     it('should default level string on unknown level', function(){
       return thisGet().then(function(body){
+        assert(body.success);
         assert.strictEqual(body.data[4].levelStr, constants.defaultLevelStr,
             'level string did not defualt');
       })

--- a/src/server/test/api.test.js
+++ b/src/server/test/api.test.js
@@ -31,11 +31,17 @@ describe('REST API', function(){
         directory: LOGFILE_PATH
       }]
     };
-    it('should successfully set the config', function(done){
-      put(CONFIG_ROUTE, config).then(body => {
-        done(body.success ? null : new Error(`Request failed: ${body.msg}`));
+    it('should successfully set the config', function(){
+      return put(CONFIG_ROUTE, config).then(body => {
+        assert(body.success, 'failed to set config');
       });
     });
+    it('should successfully get the same config', function(){
+      return get(CONFIG_ROUTE).then(body => {
+        assert(body.success, 'failed to get config');
+        assert.deepEqual(body.data, config, 'configs are not equal');
+      })
+    })
   });
 
   describe('#directory()', function(){


### PR DESCRIPTION
API responses are consistent and all reply using the same `buildRes()` helper. Two new tests are included for the server as well

This PR also addresses the issue of the default regular expressions being trimmed on parse rather than on write.